### PR TITLE
Removed InformationStream change because it is not compatible with down level v3 and v4 PowerShell

### DIFF
--- a/Pester.ThreadJob.Tests.ps1
+++ b/Pester.ThreadJob.Tests.ps1
@@ -182,13 +182,6 @@ Describe 'Basic ThreadJob Tests' -Tags 'CI' {
         $job.JobStateInfo.Reason.Message | Should Be "MyError!"
     }
 
-    It 'ThreadJob passes Information stream' {
-
-        $job = Start-ThreadJob -ScriptBlock { Write-Information "My Info"}
-        $null = $job | Receive-Job -Wait -InformationVariable info
-        $info  | Should be "My Info"
-    }
-
     It 'ThreadJob ThrottleLimit and Queue' {
 
         try

--- a/ThreadJob/ThreadJob/PSThreadJob.cs
+++ b/ThreadJob/ThreadJob/PSThreadJob.cs
@@ -438,9 +438,6 @@ namespace ThreadJob
             this.Debug = _ps.Streams.Debug;
             this.Debug.EnumeratorNeverBlocks = true;
 
-            this.Information = _ps.Streams.Information;
-            this.Information.EnumeratorNeverBlocks = true;
-
             // Create the JobManager job definition and job specification, and add to the JobManager.
             ThreadJobDefinition = new JobDefinition(typeof(ThreadJobSourceAdapter), "", Name);
             Dictionary<string, object> parameterCollection = new Dictionary<string, object>();


### PR DESCRIPTION
Unfortunately I had to remove the InformationStream change because it causes .Net runtime errors for non-existent property.