### PR TITLE
Added support for Windows CL support

### DIFF
--- a/Pester.ThreadJob.Tests.ps1
+++ b/Pester.ThreadJob.Tests.ps1
@@ -282,6 +282,12 @@ Describe 'Basic ThreadJob Tests' -Tags 'CI' {
 
         (Get-Job | where PSJobTypeName -eq "ThreadJob").Count | Should Be 0
     }
+
+    It 'ThreadJob jobs should run in FullLanguage mode by default' {
+
+        $result = Start-ThreadJob -ScriptBlock { $ExecutionContext.SessionState.LanguageMode } | Wait-Job | Receive-Job
+        $result | Should Be "FullLanguage"
+    }
 }
 
 Describe 'Job2 Tests' -Tags 'CI' {

--- a/ThreadJob.psd1
+++ b/ThreadJob.psd1
@@ -8,7 +8,7 @@
 RootModule = '.\ThreadJob.dll'
 
 # Version number of this module.
-ModuleVersion = '1.1.0'
+ModuleVersion = '1.1.1'
 
 # ID used to uniquely identify this module
 GUID = '29955884-f6a6-49ba-a071-a4dc8842697f'

--- a/ThreadJob/ThreadJob/Properties/AssemblyInfo.cs
+++ b/ThreadJob/ThreadJob/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyFileVersion("1.1.1.0")]


### PR DESCRIPTION
Powershell should run scripts in ConstrainedLanguage mode when system is locked down on Windows platforms.