### PR TITLE
Add script file policy enforcement check

### DIFF
--- a/ThreadJob.CL.Tests.ps1
+++ b/ThreadJob.CL.Tests.ps1
@@ -1,0 +1,210 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+##
+## ----------
+## Test Note:
+## ----------
+## Since these tests change session and system state (constrained language and system lockdown)
+## they will all use try/finally blocks instead of Pester AfterEach/AfterAll to ensure session
+## and system state is restored.
+## Pester AfterEach, AfterAll is not reliable when the session is constrained language or locked down.
+##
+
+function Get-RandomFileName
+{
+    [System.IO.Path]::GetFileNameWithoutExtension([IO.Path]::GetRandomFileName())
+}
+
+if ($IsWindows)
+{
+    $code = @'
+
+    #region Using directives
+
+    using System;
+    using System.Management.Automation;
+
+    #endregion
+
+    /// <summary>Adds a new type to the Application Domain</summary>
+    [Cmdlet("Invoke", "LanguageModeTestingSupportCmdlet")]
+    public sealed class InvokeLanguageModeTestingSupportCmdlet : PSCmdlet
+    {
+        [Parameter()]
+        public SwitchParameter EnableFullLanguageMode { get; set; }
+
+        [Parameter()]
+        public SwitchParameter SetLockdownMode { get; set; }
+
+        [Parameter()]
+        public SwitchParameter RevertLockdownMode { get; set; }
+
+        protected override void BeginProcessing()
+        {
+            if (EnableFullLanguageMode)
+            {
+                SessionState.LanguageMode = PSLanguageMode.FullLanguage;
+            }
+
+            if (SetLockdownMode)
+            {
+                Environment.SetEnvironmentVariable("__PSLockdownPolicy", "0x80000007", EnvironmentVariableTarget.Machine);
+            }
+
+            if (RevertLockdownMode)
+            {
+                Environment.SetEnvironmentVariable("__PSLockdownPolicy", null, EnvironmentVariableTarget.Machine);
+            }
+        }
+    }
+'@
+
+    if (-not (Get-Command Invoke-LanguageModeTestingSupportCmdlet -ErrorAction Ignore))
+    {
+        $moduleName = Get-RandomFileName
+        $moduleDirectory = join-path $TestDrive\Modules $moduleName
+        if (-not (Test-Path $moduleDirectory))
+        {
+            $null = New-Item -ItemType Directory $moduleDirectory -Force
+        }
+
+        try
+        {
+            Add-Type -TypeDefinition $code -OutputAssembly $moduleDirectory\TestCmdletForConstrainedLanguage.dll -ErrorAction Ignore
+        } catch {}
+
+        Import-Module -Name $moduleDirectory\TestCmdletForConstrainedLanguage.dll
+    }
+}
+
+try
+{
+    $defaultParamValues = $PSDefaultParameterValues.Clone()
+    $PSDefaultParameterValues["it:Skip"] = !$IsWindows
+
+    Describe "ThreadJob Constrained Language Tests" -Tags 'Feature','RequireAdminOnWindows' {
+
+        BeforeAll {
+
+            $sb = { $ExecutionContext.SessionState.LanguageMode }
+
+            $scriptTrustedFilePath = Join-Path $TestDrive "ThJobTrusted_System32.ps1"
+            @'
+            Write-Output $ExecutionContext.SessionState.LanguageMode
+'@ | Out-File -FilePath $scriptTrustedFilePath
+
+            $scriptUntrustedFilePath = Join-Path $TestDrive "ThJobUntrusted.ps1"
+            @'
+            Write-Output $ExecutionContext.SessionState.LanguageMode
+'@ | Out-File -FilePath $scriptUntrustedFilePath
+        }
+
+        It "ThreadJob script must run in ConstrainedLanguage mode with system lock down" {
+
+            try
+            {
+                $ExecutionContext.SessionState.LanguageMode = "ConstrainedLanguage"
+                Invoke-LanguageModeTestingSupportCmdlet -SetLockdownMode
+
+                $results = Start-ThreadJob -ScriptBlock { $ExecutionContext.SessionState.LanguageMode } | Wait-Job | Receive-Job
+            }
+            finally
+            {
+                Invoke-LanguageModeTestingSupportCmdlet -RevertLockdownMode -EnableFullLanguageMode
+            }
+
+            $results | Should -BeExactly "ConstrainedLanguage"
+        }
+
+        It "ThreadJob script block using variable must run in ConstrainedLanguage mode with system lock down" {
+
+            try
+            {
+                $ExecutionContext.SessionState.LanguageMode = "ConstrainedLanguage"
+                Invoke-LanguageModeTestingSupportCmdlet -SetLockdownMode
+
+                $results = Start-ThreadJob -ScriptBlock { & $using:sb } | Wait-Job | Receive-Job
+            }
+            finally
+            {
+                Invoke-LanguageModeTestingSupportCmdlet -RevertLockdownMode -EnableFullLanguageMode
+            }
+
+            $results | Should -BeExactly "ConstrainedLanguage"
+        }
+
+        It "ThreadJob script block argument variable must run in ConstrainedLanguage mode with system lock down" {
+
+            try
+            {
+                $ExecutionContext.SessionState.LanguageMode = "ConstrainedLanguage"
+                Invoke-LanguageModeTestingSupportCmdlet -SetLockdownMode
+
+                $results = Start-ThreadJob -ScriptBlock { param ($sb) & $sb } -ArgumentList $sb | Wait-Job | Receive-Job
+            }
+            finally
+            {
+                Invoke-LanguageModeTestingSupportCmdlet -RevertLockdownMode -EnableFullLanguageMode
+            }
+
+            $results | Should -BeExactly "ConstrainedLanguage"
+        }
+
+        It "ThreadJob script block piped variable must run in ConstrainedLanguage mode with system lock down" {
+
+            try
+            {
+                $ExecutionContext.SessionState.LanguageMode = "ConstrainedLanguage"
+                Invoke-LanguageModeTestingSupportCmdlet -SetLockdownMode
+
+                $results = $sb | Start-ThreadJob -ScriptBlock { $input | ForEach-Object { & $_ } } | Wait-Job | Receive-Job
+            }
+            finally
+            {
+                Invoke-LanguageModeTestingSupportCmdlet -RevertLockdownMode -EnableFullLanguageMode
+            }
+
+            $results | Should -BeExactly "ConstrainedLanguage"
+        }
+
+        It "ThreadJob untrusted script file must run in ConstrainedLanguage mode with system lock down" {
+            try 
+            {
+                $ExecutionContext.SessionState.LanguageMode = "ConstrainedLanguage"
+                Invoke-LanguageModeTestingSupportCmdlet -SetLockdownMode
+
+                $results = Start-ThreadJob -File $scriptUntrustedFilePath | Wait-Job | Receive-Job
+            }
+            finally
+            {
+                Invoke-LanguageModeTestingSupportCmdlet -RevertLockdownMode -EnableFullLanguageMode
+            }
+
+            $results | Should -BeExactly "ConstrainedLanguage"
+        }
+
+        It "ThreadJob trusted script file must run in FullLanguage mode with system lock down" {
+            try 
+            {
+                $ExecutionContext.SessionState.LanguageMode = "ConstrainedLanguage"
+                Invoke-LanguageModeTestingSupportCmdlet -SetLockdownMode
+
+                $results = Start-ThreadJob -File $scriptTrustedFilePath | Wait-Job | Receive-Job
+            }
+            finally
+            {
+                Invoke-LanguageModeTestingSupportCmdlet -RevertLockdownMode -EnableFullLanguageMode
+            }
+
+            $results | Should -BeExactly "FullLanguage"
+        }
+    }
+}
+finally
+{
+    if ($defaultParamValues -ne $null)
+    {
+        $Global:PSDefaultParameterValues = $defaultParamValues
+    }
+}

--- a/ThreadJob.psd1
+++ b/ThreadJob.psd1
@@ -8,7 +8,7 @@
 RootModule = '.\ThreadJob.dll'
 
 # Version number of this module.
-ModuleVersion = '1.1.2'
+ModuleVersion = '1.1.3'
 
 # ID used to uniquely identify this module
 GUID = '29955884-f6a6-49ba-a071-a4dc8842697f'

--- a/ThreadJob/ThreadJob/PSThreadJob.cs
+++ b/ThreadJob/ThreadJob/PSThreadJob.cs
@@ -381,7 +381,7 @@ namespace ThreadJob
                     if (!enforceLockdown && (_initSb != null))
                     {
                         // Even if the script file is trusted, an initialization script cannot be trusted, so we have to enforce
-                        // lock down.
+                        // lock down.  Otherwise untrusted script could be run in FullLanguage mode along with the trusted file script.
                         enforceLockdown = true;
                         lockdownWarning = new WarningRecord(
                             string.Format(

--- a/ThreadJob/ThreadJob/Properties/AssemblyInfo.cs
+++ b/ThreadJob/ThreadJob/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.2.0")]
-[assembly: AssemblyFileVersion("1.1.2.0")]
+[assembly: AssemblyVersion("1.1.3.0")]
+[assembly: AssemblyFileVersion("1.1.3.0")]

--- a/ThreadJob/ThreadJob/Properties/Resources.Designer.cs
+++ b/ThreadJob/ThreadJob/Properties/Resources.Designer.cs
@@ -122,5 +122,14 @@ namespace ThreadJob.Properties {
                 return ResourceManager.GetString("UsingVariableNotFound", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot run trusted script file {0} in FullLanguage mode because an initialization script block is included in the job, and the script block is not trusted..
+        /// </summary>
+        internal static string CannotRunTrustedFileInFL{
+            get {
+                return ResourceManager.GetString("CannotRunTrustedFileInFL", resourceCulture);
+            }
+        }
     }
 }

--- a/ThreadJob/ThreadJob/Properties/Resources.resx
+++ b/ThreadJob/ThreadJob/Properties/Resources.resx
@@ -138,4 +138,7 @@
   <data name="UsingVariableNotFound" xml:space="preserve">
     <value>Unable to find Using variable {0}.</value>
   </data>
+  <data name="CannotRunTrustedFileInFL" xml:space="preserve">
+    <value>Cannot run trusted script file {0} in FullLanguage mode because an initialization script block is included in the job, and the script block is not trusted.</value>
+  </data>
 </root>


### PR DESCRIPTION
Currently we check to see if Windows system is in application white listing lock down mode, and initialize the job runspace to run in ConstrainedLanguage mode.  This change adds a check for the -File parameter set to see if the script file is trusted by the lock down policy, and if it is to initialize the runspace for FullLanguage mode.  Unless an initialization script block is included, in this case the runspace remains in ConstrainedLanguage mode because a script block cannot be trusted.

Also added updated tests.