### PR TITLE
Removed ThreadJob PSHost for collecting host data.  

### DIFF
--- a/ThreadJob.CL.Tests.ps1
+++ b/ThreadJob.CL.Tests.ps1
@@ -100,6 +100,10 @@ try
 '@ | Out-File -FilePath $scriptUntrustedFilePath
         }
 
+        AfterAll {
+            Get-Job | Where-Object PSJobTypeName -eq "ThreadJob" | Remove-Job -Force
+        }
+
         It "ThreadJob script must run in ConstrainedLanguage mode with system lock down" {
 
             try

--- a/ThreadJob.Tests.ps1
+++ b/ThreadJob.Tests.ps1
@@ -236,6 +236,19 @@ Describe 'Basic ThreadJob Tests' -Tags 'CI' {
         $job.Debug | Should -Be "DebugOut"
     }
 
+    It 'ThreadJob and Information stream output' {
+
+        $job = Start-ThreadJob -ScriptBlock { Write-Information "InformationOutput" -InformationAction Continue } | Wait-Job
+        $job.Information | Should -Be "InformationOutput"
+    }
+
+    It 'ThreadJob and Host stream output' {
+
+        # Host stream data is automatically added to the Information stream
+        $job = Start-ThreadJob -ScriptBlock { Write-Host "HostOutput" } | Wait-Job
+        $job.Information | Should -Be "HostOutput"
+    }
+
     It 'ThreadJob ThrottleLimit and Queue' {
 
         try

--- a/ThreadJob.psd1
+++ b/ThreadJob.psd1
@@ -8,7 +8,7 @@
 RootModule = '.\ThreadJob.dll'
 
 # Version number of this module.
-ModuleVersion = '1.1.3'
+ModuleVersion = '2.0.0'
 
 # ID used to uniquely identify this module
 GUID = '29955884-f6a6-49ba-a071-a4dc8842697f'
@@ -41,10 +41,13 @@ number of jobs drops below the throttle limit.
 
 Added Runspace cleanup.
 Added Using variable expression support.
+Added StreamingHost parameter to stream host data writes to a provided host object.
+Added Information stream handling.
+Bumped version to 2.0.0, and now only support PowerShell version 5.1 and higher.
 "
 
 # Minimum version of the Windows PowerShell engine required by this module
-PowerShellVersion = '3.0'
+PowerShellVersion = '5.1'
 
 # Cmdlets to export from this module
 CmdletsToExport = 'Start-ThreadJob'

--- a/ThreadJob/ThreadJob/Properties/AssemblyInfo.cs
+++ b/ThreadJob/ThreadJob/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.3.0")]
-[assembly: AssemblyFileVersion("1.1.3.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]


### PR DESCRIPTION
PowerShell version 5.1 added 'Information' data stream that collects data written with 'Write-Host' and so the PSHost to collection host data and add to output hack is not needed for later versions of PowerShell.  Also, since Start-ThreadJob now provides a -StreamingHost parameter, host output data can now be streamed to any provided PSHost object.

Consequently I have removed the PSHost collection hack and also changed the minimum supported PowerShell version from 3 to 5.1.  I also bumped the module version to '2.0.0'.  I'll publish this module on PowerShell Gallery as version 2.0 and leave the latest version (1.1.2) for users who want the older behavior and need support for PowerShell V3.
