### PR TITLE
Fixed using keyword bug by removing unneeded support for V3-4

### DIFF
--- a/PSThreadJob/PSThreadJob.csproj
+++ b/PSThreadJob/PSThreadJob.csproj
@@ -4,9 +4,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>ThreadJob</RootNamespace>
     <AssemblyName>Microsoft.PowerShell.ThreadJob</AssemblyName>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <FileVersion>2.0.0</FileVersion>
-    <InformationalVersion>2.0.0</InformationalVersion>
+    <AssemblyVersion>2.0.1.0</AssemblyVersion>
+    <FileVersion>2.0.1</FileVersion>
+    <InformationalVersion>2.0.1</InformationalVersion>
     <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>

--- a/PSThreadJob/ThreadJob.psd1
+++ b/PSThreadJob/ThreadJob.psd1
@@ -8,7 +8,7 @@
 RootModule = '.\Microsoft.PowerShell.ThreadJob.dll'
 
 # Version number of this module.
-ModuleVersion = '2.0.0'
+ModuleVersion = '2.0.1'
 
 # ID used to uniquely identify this module
 GUID = 'c28d8b9b-75c0-4229-bb43-b60218c47bef'
@@ -47,6 +47,7 @@ Added Using variable expression support.
 Added StreamingHost parameter to stream host data writes to a provided host object.
 Added Information stream handling.
 Bumped version to 2.0.0, and now only support PowerShell version 5.1 and higher.
+Fixed using keyword bug with PowerShell preview version, and removed unneeded version check.
 "
 
 # Minimum version of the Windows PowerShell engine required by this module


### PR DESCRIPTION
The using keyword tests were failing for PowerShell version 7.0.0-preview.1 for two reasons:

1. The version check was not parsing this version form correctly, and was falling back to V3 behavior.
2. The V3 using keyword behavior had a bug for multiple uses of a using variable, where V3 'by array position' needs to include every instance of the using variable use.

Since we no longer support PowerShell v3,v4 with the latest ThreadJob version (2.0.0+), I simply removed the v3 behavior code and the broken version check.