### PR TITLE
Add setting the current working directory in the job runspace.

### DIFF
--- a/PSThreadJob/ThreadJob.psd1
+++ b/PSThreadJob/ThreadJob.psd1
@@ -8,10 +8,10 @@
 RootModule = '.\Microsoft.PowerShell.ThreadJob.dll'
 
 # Version number of this module.
-ModuleVersion = '2.0.1'
+ModuleVersion = '2.0.2'
 
 # ID used to uniquely identify this module
-GUID = 'c28d8b9b-75c0-4229-bb43-b60218c47bef'
+GUID = '0e7b895d-2fec-43f7-8cae-11e8d16f6e40'
 
 Author = 'Microsoft Corporation'
 CompanyName = 'Microsoft Corporation'
@@ -48,6 +48,7 @@ Added StreamingHost parameter to stream host data writes to a provided host obje
 Added Information stream handling.
 Bumped version to 2.0.0, and now only support PowerShell version 5.1 and higher.
 Fixed using keyword bug with PowerShell preview version, and removed unneeded version check.
+Added setting current working directory to running jobs, when available.
 "
 
 # Minimum version of the Windows PowerShell engine required by this module

--- a/test/ThreadJob.Tests.ps1
+++ b/test/ThreadJob.Tests.ps1
@@ -362,6 +362,12 @@ Describe 'Basic ThreadJob Tests' -Tags 'CI' {
         $result = Start-ThreadJob -ScriptBlock { $ExecutionContext.SessionState.LanguageMode } | Wait-Job | Receive-Job
         $result | Should -Be "FullLanguage"
     }
+
+    It 'ThreadJob jobs should run in the current working directory' {
+
+        $threadJobCurrentLocation = Start-ThreadJob -ScriptBlock { $pwd } | Wait-Job | Receive-Job
+        $threadJobCurrentLocation.Path | Should -BeExactly $pwd.Path
+    }
 }
 
 Describe 'Job2 class API tests' -Tags 'CI' {


### PR DESCRIPTION
This addresses issue (#46), and now all jobs will run with the session current working directory is set to the current working directory of the calling cmdlet.
