### PR TITLE
LiteralPath parameter binding when setting location

### DIFF
--- a/PSThreadJob/PSThreadJob.cs
+++ b/PSThreadJob/PSThreadJob.cs
@@ -728,7 +728,7 @@ namespace ThreadJob
                 using (var ps = PowerShell.Create())
                 {
                     ps.Runspace = _rs;
-                    ps.AddCommand("Set-Location").AddParameter("Path", _currentLocationPath).Invoke();
+                    ps.AddCommand("Set-Location").AddParameter("LiteralPath", _currentLocationPath).Invoke();
                 }
             }
 


### PR DESCRIPTION
Similar to PowerShell/PowerShell#12428 

Since `_currentLocationPath` reflects the _literal_ path currently set in the calling session, we should bind to `LiteralPath` to avoid path resolution issues with paths that might contain wildcard characters.